### PR TITLE
Add dark mode compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 
 ## About The Project
 Adds a Calendar View giving you Problem of the day based on your rating with Your Monthly Streaks!
+Now automatically adapts to your browser's dark mode.
 
 <img src='./demo_image.png'>
 

--- a/src/extension/style.css
+++ b/src/extension/style.css
@@ -18,7 +18,7 @@
 .cf-potd-container {
   /* padding: 10px; */
   margin: 20px 0;
-  background-color: #fff;
+  background-color: var(--primary-color);
   border-radius: var(--border-radius);
   /* box-shadow: var(--shadow); */
   /* border: 1px solid var(--border-color); */
@@ -134,11 +134,11 @@
 
 /* Day States */
 .calendar td.past {
-  background-color: #f5f5f5;
+  background-color: var(--secondary-color);
 }
 
 .calendar td.today {
-  background-color: #e3f2fd;
+  background-color: var(--accent-light);
   font-weight: bold;
   box-shadow: 0 0 0 2px var(--accent-color);
 }
@@ -192,7 +192,7 @@
 .container {
   width: 300px;
   padding: 20px;
-  background-color: #fff;
+  background-color: var(--primary-color);
   border-radius: var(--border-radius);
   box-shadow: var(--shadow);
 }
@@ -259,7 +259,7 @@ h1 {
 }
 
 #streakElement .streak-container {
-  background-color: #f5f5f5;
+  background-color: var(--secondary-color);
   border-radius: var(--border-radius);
   padding: 10px 15px;
   display: flex;
@@ -307,4 +307,21 @@ h1 {
   text-align: center;
   color: var(--text-light);
   padding: 10px;
+}
+
+/* Dark mode overrides using prefers-color-scheme */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary-color: #1e1e1e;
+    --secondary-color: #2a2a2a;
+    --accent-color: #5a8dd6;
+    --accent-light: #3a4f70;
+    --accent-dark: #7aa6e0;
+    --success-color: #6fbf73;
+    --warning-color: #ffa94d;
+    --error-color: #ff8787;
+    --text-color: #e0e0e0;
+    --text-light: #9e9e9e;
+    --border-color: #555555;
+  }
 }


### PR DESCRIPTION
## Summary
- refactor popup and calendar styles to use theme variables
- introduce dark mode overrides via `prefers-color-scheme`
- adjust README project blurb mentioning dark mode support

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842d680e8cc83319aeb1e1429ec8935